### PR TITLE
Separate README.md and BUILD-HOWTO.md

### DIFF
--- a/BUILD-HOWTO.md
+++ b/BUILD-HOWTO.md
@@ -1,0 +1,124 @@
+## 1. Howto Build x0-Applications (Example)
+
+The next chapters will guide you through setting up a fully functional 3-tier
+application, including a small PostgreSQL database.
+
+Our `microesb` software abstracts the relevant backend processes.
+See: https://github.com/clauspruefer/python-micro-esb.
+
+>[!NOTE]
+> Security and scaling considerations have been omitted. The *x0-system* is not
+> limited to a single backend application or database. Any system returning the
+> correct JSON schema is usable. Refer to the *x0-documentation* for JSON definitions
+> and schemas.
+
+You can also test and run your *x0-app* on GKE / Minikube (Google Kubernetes Engine).
+
+## 2. Add Database
+
+1. Remove all SQL data:
+```bash
+rm ./database/*
+```
+2. Move example database contents:
+```bash
+mv ./example/database/* ./database/*
+```
+3. Build the `your-db` Docker image:
+```bash
+cd ./docker && build-db.sh
+```
+
+Now your Docker database image is ready. Later, run:
+
+```bash
+cd ./docker && x0-start-containers.sh
+```
+
+This will start the `your-db` and `your-app` containers.
+
+>[!NOTE]
+> Building the database image does **not** require the Debian `debuild` process.
+
+## 3. Model Your Application
+
+Now it's time to explore an advanced application setup.
+
+An example (modified example #5) from the *x0-system* is used, with working backend
+services and a database. The `microesb` product abstracts OOP-based *webservice call data*.
+
+### 3.1 Example Content Explained
+
+The ./example subdirectory contains the following:
+
+| SUBDIR              | DESCRIPTION                                           |
+| ------------------- | ----------------------------------------------------- |
+| <img width="500px"> | <img width="520">                                     |
+| database            | PostgreSQL Database Definition                        |
+| docker              | Modified Dockerfile (add Python pip3 and microesb)    |
+| microesb            | Microesb Config and Service Implementation            |
+| x0-backend          | Python Backend Scripts                                |
+| x0-config           | x0 Frontend Objects Definition                        |
+
+### 3.2 Build Dir Explained
+
+The ./www subdirectory, used by Docker to build the *x0-app*, contains:
+
+| SUBDIR              | DESCRIPTION                                           |
+| ------------------- | ----------------------------------------------------- |
+| <img width="500px"> | <img width="520">                                     |
+| python              | Python Backend Scripts                                |
+| static              | x0 Frontend Objects Definition / CSS                  |
+| x0                  | x0 User Functions                                     |
+
+### 3.3 Get Application Ready
+
+1. Remove all x0 object definitions:
+```bash
+rm ./www/static/*.json
+```
+2. Move x0 objects definition to build dir
+```bash
+mv ./x0-config/* ./www/static/
+```
+3. Move Python backend scripts to build dir
+```bash
+mv ./x0-backend/* ./www/python/
+```
+4. Move microesb config and service implementation to build dir
+```bash
+mv ./microesb/* ./www/backend/
+```
+5. Replace the Dockerfile:
+```bash
+mv ./docker/app.dockerfile ./docker/app.dockerfile`
+```
+
+## 4. Rebuild / Deploy
+
+Rebuild the Debian package, Docker container, and start the application:
+
+```bash
+# build debian package
+cd ./debian && debuild
+
+# build docker containers
+cd ./docker && build-app.sh && build-db.sh
+
+# start the application
+./x0-start-containers.sh
+```
+
+Open `http://x0-skeleton-test.x0.localnet/python/Index.py`.
+
+## 5. Developing x0
+
+If you need to implement new (or enhanced) base *x0-objects*:
+
+1. Clone the x0 repository.
+2. Model / add your `sysObjNewObject.js`.
+3. Build x0 Docker containers.
+4. Rebuild your app locally.
+
+>[!NOTE]
+> Get recognition by proposing your object for inclusion in the official *x0-system*.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ within minutes using Docker or Google Kubernetes Engine (GKE).
 
 For the base x0 repository and detailed documentation, visit: https://github.com/WEBcodeX1/x0.
 
-
+Howto model an *x0-app* according to the shipped example, see: [./BUILD-HOWTO.md](./BUILD-HOWTO.md).
 
 ## 1. Dependencies / Package Installation
 
@@ -146,3 +146,40 @@ python3 ./Setup.py
 > The IP setup including DNS differs from the Docker setup and **must** be changed
 > according to the next steps.
 
+### 9.1. IP Setup / DNS
+
+```bash
+# get minikube main ip address
+minikube ip
+```
+
+Returns the current Minikube ingress IP Address (e.g. 192.168.49.2).
+
+```bash
+# get minikube ingress
+kubectl get ingress -n x0-skeleton-test
+```
+
+Returns ingress configuration for the x0-skeleton namespace.
+Add the data from column `HOST` and `ADDRESS` to `/etc/hosts` or DNS zone file.
+
+>[!NOTE]
+> Change IP address if already used in Docker context.
+
+### 9.2. Check Pod Status
+
+Finally check pod status.
+
+```bash
+# get pods status
+kubectl get pods -n x0-skeleton-test
+```
+
+```bash
+NAME                                        READY   STATUS
+mypostgres-1-0                              1/1     Running
+mypostgres-2-0                              1/1     Running
+your-app-test-db-install                    0/1     Completed
+your-app-test-deployment-6cb48779f9-cq2sb   1/1     Running
+your-app-test-deployment-6cb48779f9-d5sf9   1/1     Running
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # x0-skeleton
 
-x0 JS Framework Application Skeleton Repository.
+**x0 JS Framework Application Skeleton Repository**.
 
 This repository contains the skeleton setup required to run your *x0-application*
 within minutes using Docker or Google Kubernetes Engine (GKE).
@@ -12,6 +12,8 @@ within minutes using Docker or Google Kubernetes Engine (GKE).
 > your *x0-app* or making any changes.
 
 For the base x0 repository and detailed documentation, visit: https://github.com/WEBcodeX1/x0.
+
+
 
 ## 1. Dependencies / Package Installation
 
@@ -85,7 +87,7 @@ Provide the following details for default package signing:
 - `Real Name`: Your Name
 - `Email address`: you@domain.online
 - `Comment`: YourPosition
-  
+
 ```bash
 # build debian packages
 cd ./debian && debuild
@@ -124,127 +126,23 @@ cd ./docker && x0-start-containers.sh
 Open `http://x0-skeleton-test.x0.localnet/python/Index.py` in your browser.
 A `Hello World.` text should be displayed.
 
-## 9. Short Interception
+## 9. Kubernetes Minikube
 
-The next chapters will guide you through setting up a fully functional 3-tier
-application, including a small PostgreSQL database.
+By starting the kubernetes installer (`Setup.py`) using the unmodified
+`./config/app-config.json` metadata, the following Minikube infrastructure on
+Linux will be built.
 
-Our `microesb` software abstracts the relevant backend processes.
-See: https://github.com/clauspruefer/python-micro-esb.
+- 2 x0 Application Pods
+- 2 Database (replicating) Pods (Kubegres)
+- Ingress LoadBalancing (nginx)
+
+```bash
+# setup minikube environment
+cd ./kubernetes/setup/
+python3 ./Setup.py
+```
 
 >[!NOTE]
-> Security and scaling considerations have been omitted. The *x0-system* is not
-> limited to a single backend application or database. Any system returning the
-> correct JSON schema is usable. Refer to the *x0-documentation* for JSON definitions
-> and schemas.
+> The IP setup including DNS differs from the Docker setup and **must** be changed
+> according to the next steps.
 
-You can also test and run your *x0-app* on GKE / Minikube (Google Kubernetes Engine).
-
-## 10. Add Database
-
-1. Remove all SQL data:
-```bash
-rm ./database/*
-```
-2. Move example database contents:
-```bash
-mv ./example/database/* ./database/*
-```
-3. Build the `your-db` Docker image:
-```bash
-cd ./docker && build-db.sh
-```
-
-Now your Docker database image is ready. Later, run:
-
-```bash
-cd ./docker && x0-start-containers.sh
-```
-
-This will start the `your-db` and `your-app` containers.
-
->[!NOTE]
-> Building the database image does **not** require the Debian `debuild` process.
-
-## 11. Model Your Application
-
-Now it's time to explore an advanced application setup.
-
-An example (modified example #5) from the *x0-system* is used, with working backend
-services and a database. The `microesb` product abstracts OOP-based *webservice call data*.
-
-### 11.1 Example Content Explained
-
-The ./example subdirectory contains the following:
-
-| SUBDIR              | DESCRIPTION                                           |
-| ------------------- | ----------------------------------------------------- |
-| <img width="500px"> | <img width="520">                                     |
-| database            | PostgreSQL Database Definition                        |
-| docker              | Modified Dockerfile (add Python pip3 and microesb)    |
-| microesb            | Microesb Config and Service Implementation            |
-| x0-backend          | Python Backend Scripts                                |
-| x0-config           | x0 Frontend Objects Definition                        |
-
-### 11.2 Build Dir Explained
-
-The ./www subdirectory, used by Docker to build the *x0-app*, contains:
-
-| SUBDIR              | DESCRIPTION                                           |
-| ------------------- | ----------------------------------------------------- |
-| <img width="500px"> | <img width="520">                                     |
-| python              | Python Backend Scripts                                |
-| static              | x0 Frontend Objects Definition / CSS                  |
-| x0                  | x0 User Functions                                     |
-
-### 11.3 Get Application Ready
-
-1. Remove all x0 object definitions:
-```bash
-rm ./www/static/*.json
-```
-2. Move x0 objects definition to build dir
-```bash
-mv ./x0-config/* ./www/static/
-```
-3. Move Python backend scripts to build dir
-```bash
-mv ./x0-backend/* ./www/python/
-```
-4. Move microesb config and service implementation to build dir
-```bash
-   mv ./microesb/* ./www/backend/
-```
-5. Replace the Dockerfile:
-```bash
-mv ./docker/app.dockerfile ./docker/app.dockerfile`
-```
-
-## 12. Rebuild / Deploy
-
-Rebuild the Debian package, Docker container, and start the application:
-
-```bash
-# build debian package
-cd ./debian && debuild
-
-# build docker containers
-cd ./docker && build-app.sh && build-db.sh
-
-# start the application
-./x0-start-containers.sh
-```
-
-Open `http://x0-skeleton-test.x0.localnet/python/Index.py`.
-
-## 13. Developing x0
-
-If you need to implement new (or enhanced) base *x0-objects*:
-
-1. Clone the x0 repository.
-2. Model / add your `sysObjNewObject.js`.
-3. Build x0 Docker containers.
-4. Rebuild your app locally.
-
->[!NOTE]
-> Get recognition by proposing your object for inclusion in the official *x0-system*.


### PR DESCRIPTION
Logical separate `README.md` and `BUILD-HOWTO.md`.

Still missing:
- Link from README.md to BUILD-HOWTO.md
- Detailed Kubernetes IP/DNS setup