### PR TITLE
Unneeded entry, cripples install

### DIFF
--- a/debian/x0-skeleton-data.install
+++ b/debian/x0-skeleton-data.install
@@ -1,4 +1,3 @@
 config/* /var/lib/x0/app-config
 python /var/lib/x0/app-install
 www /var/lib/x0/app-install
-www/x0/* /var/lib/x0/app-install


### PR DESCRIPTION
Entry caused overwriting.