### PR TITLE
Fix Example1 Database Connection Broken After 1 MicroESB Service Call

### DIFF
--- a/example/01-forms-microesb/microesb/service_implementation.py
+++ b/example/01-forms-microesb/microesb/service_implementation.py
@@ -10,7 +10,7 @@ class User(microesb.ClassHandler):
         self.DB_user_id = None
 
     def init(self):
-        crs = self.dbcon.cursor()
+        crs = self.dbcon.cursor(cursor_factory=psycopg2.extras.DictCursor)
         crs.execute("""
             SELECT id
                 FROM sys_core."user"
@@ -33,7 +33,7 @@ class Domain(microesb.ClassHandler):
         self.DB_user_id = self.parent_object.DB_user_id
         self.dbcon = self.parent_object.dbcon
 
-        crs = self.dbcon.cursor()
+        crs = self.dbcon.cursor(cursor_factory=psycopg2.extras.DictCursor)
         crs.execute(
             """
             SELECT id
@@ -76,7 +76,7 @@ class Host(microesb.MultiClassHandler):
         if len(self.priority) == 0:
             self.priority = 0
 
-        crs = self.dbcon.cursor()
+        crs = self.dbcon.cursor(cursor_factory=psycopg2.extras.DictCursor)
         crs.execute(
             """
             INSERT INTO sys_dns.dnsrecord
@@ -92,4 +92,3 @@ class Host(microesb.MultiClassHandler):
                 self.priority,
             )
         )
-


### PR DESCRIPTION
# Pull Request

## Description / Symptoms

After 1 MicroESB invocation the database connection is lost. This is probably due to the static declaration of dbcon inside the global Python address space. Python should never do this: static in this scope **is static** and never should be garbage collected. This is a consumption and i could be wrong!

## Quick Solution

This example is not performance-related, so switching globally to dbpool (which is already used in `getDomainsPulldown.py`) should do the trick. 

## Expected Behaviour

The DB connection should be reconnected on loss, multiple MicroESB calls will be possible after implementation.

## Type of Change

- [x] Bug fix
